### PR TITLE
[NL-33] Gamplay Tag (Status.Combat) 이 Proxy Client 환경에서 적용 안되는 이슈

### DIFF
--- a/Source/ProjectNL/Character/BaseCharacter.cpp
+++ b/Source/ProjectNL/Character/BaseCharacter.cpp
@@ -4,6 +4,7 @@
 #include "ProjectNL/Component/EquipComponent/EquipComponent.h"
 #include "ProjectNL/GAS/Attribute/BaseAttributeSet.h"
 #include "GameFramework/CharacterMovementComponent.h"
+#include "ProjectNL/Helper/GameplayTagHelper.h"
 
 
 ABaseCharacter::ABaseCharacter()
@@ -16,6 +17,18 @@ void ABaseCharacter::BeginPlay()
 {
 	Super::BeginPlay();
 }
+
+void ABaseCharacter::Initialize()
+{
+	if (AbilitySystemComponent)
+	{
+		if (GetEquipComponent()->GetIsFirstEquipWeapon())
+		{
+			AbilitySystemComponent->AddLooseGameplayTag(NlGameplayTags::Status_Combat);
+		}
+	}
+}
+
 
 void ABaseCharacter::Server_ApplyGameplayEffectToSelf_Implementation(
 	TSubclassOf<UGameplayEffect> Effect, const uint32 Level)

--- a/Source/ProjectNL/Character/BaseCharacter.h
+++ b/Source/ProjectNL/Character/BaseCharacter.h
@@ -32,6 +32,7 @@ public:
 		TSubclassOf<UGameplayEffect> Effect);
 	
 	GETTER(UEquipComponent*, EquipComponent)
+	GETTER_SETTER(EEntityCategory, EntityType)
 	
 protected:
 	virtual void BeginPlay() override;
@@ -41,15 +42,16 @@ protected:
 	
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
 	UEquipComponent* EquipComponent;
+	
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "AbilitySystem"
+		, meta = (AllowPrivateAccess = "true"))
+	FNLAbilitySystemInitializationData InitializeData;
 
 	void MovementSpeedChanged(const FOnAttributeChangeData& Data);
+	
+	void Initialize();
 private:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Entity|Category"
 		, meta = (AllowPrivateAccess = "true"))
 	EEntityCategory EntityType;
-	GETTER_SETTER(EEntityCategory, EntityType);
-
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "AbilitySystem"
-		, meta = (AllowPrivateAccess = "true"))
-	FNLAbilitySystemInitializationData InitializeData;
 };

--- a/Source/ProjectNL/Character/Player/PlayerCharacter.cpp
+++ b/Source/ProjectNL/Character/Player/PlayerCharacter.cpp
@@ -63,6 +63,8 @@ void APlayerCharacter::OnRep_PlayerState()
 		AbilitySystemComponent->GetGameplayAttributeValueChangeDelegate(
 			PlayerAttributeSet->GetMovementSpeedAttribute()).AddUObject(
 			this, &ThisClass::MovementSpeedChanged);
+
+		Initialize();
 	}
 }
 
@@ -85,6 +87,8 @@ void APlayerCharacter::PossessedBy(AController* NewController)
 		AbilitySystemComponent->GetGameplayAttributeValueChangeDelegate(
 			PlayerAttributeSet->GetMovementSpeedAttribute()).AddUObject(
 			this, &ThisClass::MovementSpeedChanged);
+		
+		Initialize();
 	}
 }
 

--- a/Source/ProjectNL/Component/EquipComponent/EquipComponent.cpp
+++ b/Source/ProjectNL/Component/EquipComponent/EquipComponent.cpp
@@ -19,13 +19,9 @@ void UEquipComponent::BeginPlay()
 	{
 		MainWeapon = GetWorld()->SpawnActor<ABaseWeapon>(MainWeaponClass);
 		SubWeapon = GetWorld()->SpawnActor<ABaseWeapon>(SubWeaponClass);
+		
 		if (IsFirstEquipWeapon)
 		{
-			if (UAbilitySystemComponent* ASC = Character->GetAbilitySystemComponent())
-			{
-				ASC->SetLooseGameplayTagCount(NlGameplayTags::Status_Combat, 1);
-			}
-			
 			if (MainWeapon)
             {
              	MainWeapon->EquipCharacterWeapon(Character, true);

--- a/Source/ProjectNL/Component/EquipComponent/EquipComponent.h
+++ b/Source/ProjectNL/Component/EquipComponent/EquipComponent.h
@@ -18,6 +18,8 @@ public:
 	UEquipComponent();
 
 	void UpdateEquipWeaponAnimationData();
+
+	GETTER(bool, IsFirstEquipWeapon)
 	
 	// ABP에서 주로 사용함.
 	GETTER(TArray<TObjectPtr<UAnimMontage>>, ComboAttackAnim)

--- a/Source/ProjectNL/Helper/UtilHelper.h
+++ b/Source/ProjectNL/Helper/UtilHelper.h
@@ -5,17 +5,14 @@ class FUtilHelper
 };
 
 #define GETTER(type, varName) \
-public: \
 UFUNCTION(BlueprintCallable) \
 FORCEINLINE type Get##varName() { return varName; }
 
 #define SETTER(type, varName) \
-public: \
 UFUNCTION(BlueprintCallable) \
 FORCEINLINE void Set##varName(type val) { varName = val; }
 
 #define GETTER_SETTER(type, varName) \
-public: \
 UFUNCTION(BlueprintCallable) \
 FORCEINLINE type Get##varName() { return varName; } \
 UFUNCTION(BlueprintCallable) \


### PR DESCRIPTION
# 개요
> 클라이언트 환경에서 Status.Combat 태그가 적용이 안되는 이슈 수정

# 작업 내용
- Basecharacter에서 해당 태그를 초기화해주는 메소드 추가
- Player Character에서 OnRep_PlayerState, PossessedBy 함수에서 GAS의 Replicated가 끝난 이후 작업해주게 설정

## 영상 자료 첨부 (선택)
X

## PR Dependency (선택)
X

# 티켓 링크
https://project-nl.atlassian.net/browse/NL-33

# 변경 카테고리

- [x] 버그 수정
- [ ] 새로운 feature
- [ ] 문서 추가, 변경
- [ ] 리팩토링
