### PR TITLE
[NL-45] Anim Notify 내부 로직 버그 수정

### DIFF
--- a/Source/ProjectNL/GAS/Ability/Active/Default/ComboAttack/AnimNotify/EnableCollisionNotifyState.h
+++ b/Source/ProjectNL/GAS/Ability/Active/Default/ComboAttack/AnimNotify/EnableCollisionNotifyState.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "Animation/AnimNotifies/AnimNotifyState.h"
 #include "EnableCollisionNotifyState.generated.h"
+class UCharacterAnimInstance;
 class UGameplayEffect;
 /**
  * 
@@ -24,18 +25,12 @@ public:
 protected:
 	void PerformTriangleTrace(AActor* Owner, FVector Point1, FVector Point2, FVector Point3, TArray<FHitResult>& OutHitResults);
 
-	void MakeTriangleTrace(AActor* Character);
-private:
+	void MakeTriangleTrace(AActor* owner);
+
 	
 
-	UPROPERTY()
-	TSet<AActor*> HitActors;
 
-	UPROPERTY(EditAnywhere, Category = "GAS")
-	TSubclassOf<UGameplayEffect> AttackDamageEffect;
-	// 이전 프레임의 소켓 위치를 저장하는 벡터
-	FVector PrevStartLocation;
-	FVector PrevEndLocation;
+	
 
 	
 };

--- a/Source/ProjectNL/Weapon/BaseWeapon.cpp
+++ b/Source/ProjectNL/Weapon/BaseWeapon.cpp
@@ -68,3 +68,8 @@ void ABaseWeapon::SwapTwoHandWeapon()
 											, "weapon_twoHand");
 	}
 }
+
+TSet<AActor*>& ABaseWeapon::GetHitActorsReference()
+{
+	return HitActors;
+}

--- a/Source/ProjectNL/Weapon/BaseWeapon.h
+++ b/Source/ProjectNL/Weapon/BaseWeapon.h
@@ -22,10 +22,16 @@ public:
 	void UnEquipCharacterWeapon(ACharacter* Character, const bool IsMain);
 	void SwapTwoHandWeapon();
 
+	TSet<AActor*>& GetHitActorsReference();
 	GETTER(EUEquippedHandType, EquippedHandType)
 	GETTER(EWeaponAttachPosition, AttachPosition)
 	GETTER(EUWeaponType, WeaponType)
 	GETTER(USkeletalMeshComponent*, WeaponSkeleton)
+
+	GETTER_SETTER(FVector, PrevStartLocation)
+	GETTER_SETTER(FVector, PrevEndLocation)
+	GETTER_SETTER(TSet<AActor*>, HitActors)
+
 protected:
 	virtual void BeginPlay() override;
 	
@@ -44,4 +50,11 @@ protected:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Assets
 		, meta = (AllowPrivateAccess = "true"))
 	EWeaponAttachPosition AttachPosition;
+
+	UPROPERTY()
+	TSet<AActor*> HitActors;
+
+	// 캐릭터별로 관리할 변수 선언
+	FVector PrevStartLocation;
+	FVector PrevEndLocation;
 };


### PR DESCRIPTION
1.애님노티파이스테이트의 매개변수들을 무기로 이동

# 개요
모든 캐릭터 애니메이션의 AnimNotify가 동일한 포인터를 가지고 있다.(애님 몽타주를 같은 인스턴스로 사용)
같은 Asset을 바라보고 있기에 생기는 이슈로 보여 AnimNotify 내부에서 동작하는 로직이나, 변수를 외부 즉 캐릭터 별로 빼야하는 작업을 수행해야함.

# 작업 내용
- 애님노티파이스테이트의 매개변수들을 무기로 이동
- 
# 티켓 링크
https://project-nl.atlassian.net/browse/NL-[45]

# 변경 카테고리

- [ ] 버그 수정
- [ ] 새로운 feature
- [ ] 문서 추가, 변경
- [x] 리팩토링
