### PR TITLE
[NL-49] : 충돌 트레이스 리플리케이션 수정

### DIFF
--- a/Source/ProjectNL/GAS/Ability/Active/Default/ComboAttack/AnimNotify/EnableCollisionNotifyState.cpp
+++ b/Source/ProjectNL/GAS/Ability/Active/Default/ComboAttack/AnimNotify/EnableCollisionNotifyState.cpp
@@ -10,6 +10,7 @@
 void UEnableCollisionNotifyState::NotifyBegin(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, float TotalDuration)
 {
     UE_LOG(LogTemp, Log, TEXT("Notify Begin"));
+
     ABaseCharacter* Owner = Cast<ABaseCharacter>(MeshComp->GetOwner());
 
     UEquipComponent* EquipComponent{};
@@ -37,10 +38,16 @@ void UEnableCollisionNotifyState::NotifyBegin(USkeletalMeshComponent* MeshComp, 
         SubWeapon->SetPrevStartLocation(FVector::ZeroVector); 
         SubWeapon->SetPrevEndLocation(FVector::ZeroVector);
     }
+    
+    if (Owner->HasAuthority())
+    {
+        return;
+    }
 }
 
 void UEnableCollisionNotifyState::NotifyTick(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, float FrameDeltaTime, const FAnimNotifyEventReference& EventReference)
 {
+    
     Super::NotifyTick(MeshComp, Animation, FrameDeltaTime, EventReference);
     if (AActor* Owner = MeshComp->GetOwner())
     {


### PR DESCRIPTION

# 개요
> 서버와 클라에서 동시에 충돌라인트레이스가 나와 충돌처리가 2번 되는 문제 


# 작업 내용
본인이 작업한 부분에 대해 조금 더 적어주시면 좋습니다.
- 애님 노티파이스테이트에서 서버일 경우  진행하지 못하도록 변경


# 티켓 링크
https://project-nl.atlassian.net/browse/NL-49

# 변경 카테고리

- [x] 버그 수정
- [ ] 새로운 feature
- [ ] 문서 추가, 변경
- [ ] 리팩토링
